### PR TITLE
Improve STL-10 dataset loading resilience

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -28,6 +28,15 @@ from datasets import load_dataset
 ds = load_dataset("Shu1L0n9/CleanSTL-10")
 ```
 
+> 🔐 Running the provided scripts (for example `scripts/extract_features.py`) will automatically pick up a
+> Hugging Face token stored in the `HF_TOKEN` environment variable or the `stl10_token` field in
+> `src/config/config.py`. Export your token before launching a script:
+>
+> ```bash
+> export HF_TOKEN=hf_your_token_here
+> python scripts/extract_features.py --dataset_type stl10
+> ```
+
 ### 🔧 Load with WebDataset
 
 ```python
@@ -156,6 +165,7 @@ jupyter lab experiment.ipynb
 The main configuration file is located at `src/config/config.py`, including:
 
 - **Data config**: Dataset type, path, batch size, etc.
+- **STL-10 config**: Hugging Face repository (`stl10_dataset_repo`), split names (`stl10_train_split`, `stl10_test_split`), and optional authentication token (`stl10_token`).
 - **Model config**: Number of PCA components, number of GMM components, convergence threshold, etc.
 - **ViT config**: Pretrained model selection, device configuration, etc.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,4 @@ timm==1.0.15
 torch==2.6.0
 torchvision==0.21.0
 tqdm==4.67.1
+datasets==3.1.0

--- a/scripts/extract_features.py
+++ b/scripts/extract_features.py
@@ -57,7 +57,11 @@ def extract_features():
         'data_root': config.data.data_root,
         'batch_size': config.data.batch_size,
         'image_size': config.data.image_size,
-        'compute_norm': config.data.compute_norm
+        'compute_norm': config.data.compute_norm,
+        'stl10_dataset_repo': config.data.stl10_dataset_repo,
+        'stl10_train_split': config.data.stl10_train_split,
+        'stl10_test_split': config.data.stl10_test_split,
+        'stl10_token': config.data.stl10_token
     }
     
     data_loader = DatasetLoader(data_config)

--- a/src/config/config.py
+++ b/src/config/config.py
@@ -14,6 +14,10 @@ class DataConfig:
     batch_size: int = 64
     image_size: int = 518
     compute_norm: bool = True
+    stl10_dataset_repo: str = 'Shu1L0n9/CleanSTL-10'
+    stl10_train_split: str = 'train_labeled'
+    stl10_test_split: str = 'test'
+    stl10_token: Optional[str] = os.getenv('HF_TOKEN')
     
     @property
     def n_classes(self) -> int:

--- a/src/data/data_loader.py
+++ b/src/data/data_loader.py
@@ -1,12 +1,62 @@
+import os
+import random
+from collections import defaultdict
+from typing import Optional
+
+import numpy as np
 import torch
 import torchvision
 import torchvision.transforms as transforms
-from torch.utils.data import Dataset, DataLoader
-import os
+from datasets import DownloadConfig, load_dataset
+from PIL import Image
+from torch.utils.data import DataLoader, Dataset
 from tqdm import tqdm
-import numpy as np
-from collections import defaultdict
-import random
+
+from huggingface_hub.utils import HfHubHTTPError
+from requests.exceptions import (
+    ConnectionError as RequestsConnectionError,
+    HTTPError as RequestsHTTPError,
+    ProxyError,
+)
+
+
+class HuggingFaceImageDataset(Dataset):
+    """Wrap a Hugging Face dataset to provide torchvision-style transforms."""
+
+    def __init__(self, dataset, transform: Optional[transforms.Compose] = None):
+        self.dataset = dataset
+        self._transform = transform
+
+    @property
+    def transform(self):
+        return self._transform
+
+    @transform.setter
+    def transform(self, value):
+        self._transform = value
+
+    def __len__(self):
+        return len(self.dataset)
+
+    def __getitem__(self, idx):
+        example = self.dataset[idx]
+        image = example["image"]
+        if not isinstance(image, Image.Image):
+            image = Image.fromarray(image)
+
+        if self._transform is not None:
+            image = self._transform(image)
+
+        label = example.get("label", -1)
+        if label is None:
+            label = -1
+
+        try:
+            label = int(label)
+        except (TypeError, ValueError):
+            label = -1
+
+        return image, label
 
 def compute_normalization(dataset, batch_size=1024, input_size=32):
     """Compute normalization parameters for the dataset"""
@@ -143,17 +193,50 @@ class DatasetLoader:
     def _load_datasets(self):
         """Load datasets according to configuration"""
         if self.dataset_type == 'stl10':
-            self.train_dataset = torchvision.datasets.STL10(
-                root=self.config.get('data_root', './data'),
-                split='train',
-                download=True,
+            dataset_repo = self.config.get('stl10_dataset_repo', 'Shu1L0n9/CleanSTL-10')
+            train_split = self.config.get('stl10_train_split', 'train_labeled')
+            test_split = self.config.get('stl10_test_split', 'test')
+            token = self.config.get('stl10_token') or os.getenv('HF_TOKEN')
+
+            download_config = DownloadConfig(token=token) if token else None
+
+            try:
+                stl10_dataset = load_dataset(
+                    dataset_repo,
+                    download_config=download_config,
+                )
+            except (ProxyError, RequestsConnectionError, ConnectionError) as exc:
+                raise RuntimeError(
+                    "Failed to download the STL-10 dataset from Hugging Face due to a network or proxy "
+                    "error. Please verify your internet connection, proxy configuration, or download the "
+                    "dataset manually via `huggingface-cli` before retrying."
+                ) from exc
+            except (RequestsHTTPError, HfHubHTTPError) as exc:
+                raise RuntimeError(
+                    f"Failed to access dataset '{dataset_repo}' on the Hugging Face Hub. "
+                    "Ensure the repository exists and that your access token has permission to read it."
+                ) from exc
+
+            missing_splits = [
+                split_name
+                for split_name in (train_split, test_split)
+                if split_name not in stl10_dataset
+            ]
+            if missing_splits:
+                available_splits = ", ".join(sorted(stl10_dataset.keys()))
+                raise KeyError(
+                    "The following STL-10 splits could not be found in the Hugging Face dataset: "
+                    f"{', '.join(missing_splits)}. Available splits: {available_splits}. "
+                    "Please verify your configuration."
+                )
+
+            self.train_dataset = HuggingFaceImageDataset(
+                stl10_dataset[train_split],
                 transform=self.train_transform
             )
-            
-            self.test_dataset = torchvision.datasets.STL10(
-                root=self.config.get('data_root', './data'),
-                split='test',
-                download=True,
+
+            self.test_dataset = HuggingFaceImageDataset(
+                stl10_dataset[test_split],
                 transform=self.test_transform
             )
             


### PR DESCRIPTION
## Summary
- default the STL-10 configuration token to the `HF_TOKEN` environment variable and document how to supply it when running scripts
- harden the Hugging Face STL-10 loader with download configuration, split validation, and clearer error messages when access fails

## Testing
- HF_TOKEN=<token> python - <<'PY'
from src.data.data_loader import DatasetLoader

config = {
    'dataset_type': 'stl10',
    'batch_size': 2,
    'image_size': 32,
}

DatasetLoader(config)
PY *(fails: ProxyError/403 due to restricted proxy in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68da1cc3eefc833198ed913fb2ef4dd2